### PR TITLE
Schema extension for WATERVERSE use case

### DIFF
--- a/CONTRIBUTORS.yaml
+++ b/CONTRIBUTORS.yaml
@@ -42,5 +42,12 @@ contributors:
   project: SALTED. https://salted-project.eu/
   comments:
   year: 2023
+- name: Grigoris
+  surname: Stathopoulos
+  mail: grigstat@iti.gr
+  organization: CERTH
+  project: WATERVERSE. https://waterverse.eu/
+  comments:
+  year: 2024
 
 

--- a/DataQualityAssessment/ADOPTERS.yaml
+++ b/DataQualityAssessment/ADOPTERS.yaml
@@ -7,3 +7,10 @@ currentAdopters:
   project: https://salted-project.eu/
   comments: 
   startDate: 
+- adopter: WATERVERSE project
+  description: Data Quality Assurance tool
+  mail: 
+  organization: 
+  project: https://waterverse.eu/
+  comments: 
+  startDate: 

--- a/DataQualityAssessment/examples/example-normalized.json
+++ b/DataQualityAssessment/examples/example-normalized.json
@@ -33,32 +33,32 @@
   },
   "dataQualityAssessmentDomains": {
     "type": "object",
-    "properties": {
+    "value": {
       "completeness": {
         "type": "array",
-        "items": [1,1,1,1,1,1,1,0.9865,1,1,0.9595,0.9595]
+        "value": [1,1,1,1,1,1,1,0.9865,1,1,0.9595,0.9595]
       },
       "consistency": {
         "type": "array",
-        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+        "value": [1,1,1,1,1,1,1,1,1,1,1,1]
       },
       "timeliness": {
         "type": "array",
-        "items": [0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9211,0.9342,0.9342,0.8947,0.8947]
+        "value": [0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9211,0.9342,0.9342,0.8947,0.8947]
       },
       "uniqueness": {
         "type": "array",
-        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+        "value": [1,1,1,1,1,1,1,1,1,1,1,1]
       },
       "validity": {
         "type": "array",
-        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+        "value": [1,1,1,1,1,1,1,1,1,1,1,1]
       }
     }
   },
   "dataQualityAssessmentVariableNames": {
       "type": "array",
-      "items": [
+      "value": [
         "dataProvider",
         "dateObserved",
         "entityId",

--- a/DataQualityAssessment/examples/example-normalized.json
+++ b/DataQualityAssessment/examples/example-normalized.json
@@ -31,6 +31,48 @@
       "methodology": "urn:ngsi-ld:AI-Methodology:Synthetic:Temperature:smartsantander:u7jcfa:f3058"
     }
   },
+  "dataQualityAssessmentDomains": {
+    "type": "object",
+    "properties": {
+      "completeness": {
+        "type": "array",
+        "items": [1,1,1,1,1,1,1,0.9865,1,1,0.9595,0.9595]
+      },
+      "consistency": {
+        "type": "array",
+        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+      },
+      "timeliness": {
+        "type": "array",
+        "items": [0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9211,0.9342,0.9342,0.8947,0.8947]
+      },
+      "uniqueness": {
+        "type": "array",
+        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+      },
+      "validity": {
+        "type": "array",
+        "items": [1,1,1,1,1,1,1,1,1,1,1,1]
+      }
+    }
+  },
+  "dataQualityAssessmentVariableNames": {
+      "type": "array",
+      "items": [
+        "dataProvider",
+        "dateObserved",
+        "entityId",
+        "location.coordinates.0",
+        "location.coordinates.1",
+        "location.type",
+        "precipitation",
+        "relativeHumidity",
+        "temperature",
+        "entityType",
+        "windDirection",
+        "windSpeed"
+    ]  
+  },
   "precision": {
     "type": "Number",
     "value": 1.3

--- a/DataQualityAssessment/examples/example.json
+++ b/DataQualityAssessment/examples/example.json
@@ -17,6 +17,27 @@
     "isSynthetic": false,
     "methodology": "urn:ngsi-ld:AI-Methodology:Synthetic:Temperature:smartsantander:u7jcfa:f3058"
   },
+  "dataQualityAssessmentDomains": {
+      "completeness":[1,1,1,1,1,1,1,0.9865,1,1,0.9595,0.9595],
+      "consistency":[1,1,1,1,1,1,1,1,1,1,1,1],
+      "timeliness": [0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9342,0.9211,0.9342,0.9342,0.8947,0.8947],
+      "uniqueness": [1,1,1,1,1,1,1,1,1,1,1,1],
+      "validity": [1,1,1,1,1,1,1,1,1,1,1,1]
+  },
+  "dataQualityAssessmentVariableNames": [
+      "dataProvider",
+      "dateObserved",
+      "entityId",
+      "location.coordinates.0",
+      "location.coordinates.1",
+      "location.type",
+      "precipitation",
+      "relativeHumidity",
+      "temperature",
+      "entityType",
+      "windDirection",
+      "windSpeed"
+  ],
   "accuracy": 0.25,
   "timeliness": 3,
   "precision": 1.3,

--- a/DataQualityAssessment/schema.json
+++ b/DataQualityAssessment/schema.json
@@ -131,7 +131,8 @@
           "type": "array",
           "description": "Array of variable names used to describe the values for each dataQualityAssessmentDomain property",
           "items": {
-            "type": "string"
+            "type": "string",
+            "description": "Property. Every item in the variable names array"
           }
         },
         "dataQualityAssessmentDomains": {
@@ -143,6 +144,7 @@
               "description": "Completeness scores for variables",
               "items": {
                 "type": "number",
+                "description": "Property. Every item in the completeness array",
                 "minimum": 0,
                 "maximum": 1
               }
@@ -152,6 +154,7 @@
               "description": "Consistency scores for variables",
               "items": {
                 "type": "number",
+                "description": "Property. Every item in the consistency array",
                 "minimum": 0,
                 "maximum": 1
               }
@@ -161,6 +164,7 @@
               "description": "Timeliness scores for variables",
               "items": {
                 "type": "number",
+                "description": "Property. Every item in the timeliness array",
                 "minimum": 0,
                 "maximum": 1
               }
@@ -170,6 +174,7 @@
               "description": "Uniqueness scores for variables",
               "items": {
                 "type": "number",
+                "description": "Property. Every item in the uniqueness array",
                 "minimum": 0,
                 "maximum": 1
               }
@@ -179,6 +184,7 @@
               "description": "Validity scores for variables",
               "items": {
                 "type": "number",
+                "description": "Property. Every item in the validity array",
                 "minimum": 0,
                 "maximum": 1
               }

--- a/DataQualityAssessment/schema.json
+++ b/DataQualityAssessment/schema.json
@@ -129,7 +129,7 @@
         },
         "dataQualityAssessmentVariableNames": {
           "type": "array",
-          "description": "Array of variable names used to describe the values for each dataQualityAssessmentDomain property",
+          "description": "Relationship. Array of variable names used to describe the values for each dataQualityAssessmentDomain property",
           "items": {
             "type": "string",
             "description": "Property. Every item in the variable names array"
@@ -137,11 +137,11 @@
         },
         "dataQualityAssessmentDomains": {
           "type": "object",
-          "description": "Data quality assessment domains with their respective scores",
+          "description": "Property. Data quality assessment domains with their respective scores",
           "properties": {
             "completeness": {
               "type": "array",
-              "description": "Completeness scores for variables",
+              "description": "Property. Completeness scores for variables",
               "items": {
                 "type": "number",
                 "description": "Property. Every item in the completeness array",
@@ -151,7 +151,7 @@
             },
             "consistency": {
               "type": "array",
-              "description": "Consistency scores for variables",
+              "description": "Property. Consistency scores for variables",
               "items": {
                 "type": "number",
                 "description": "Property. Every item in the consistency array",
@@ -161,7 +161,7 @@
             },
             "timeliness": {
               "type": "array",
-              "description": "Timeliness scores for variables",
+              "description": "Property. Timeliness scores for variables",
               "items": {
                 "type": "number",
                 "description": "Property. Every item in the timeliness array",
@@ -171,7 +171,7 @@
             },
             "uniqueness": {
               "type": "array",
-              "description": "Uniqueness scores for variables",
+              "description": "Property. Uniqueness scores for variables",
               "items": {
                 "type": "number",
                 "description": "Property. Every item in the uniqueness array",
@@ -181,7 +181,7 @@
             },
             "validity": {
               "type": "array",
-              "description": "Validity scores for variables",
+              "description": "Property. Validity scores for variables",
               "items": {
                 "type": "number",
                 "description": "Property. Every item in the validity array",

--- a/DataQualityAssessment/schema.json
+++ b/DataQualityAssessment/schema.json
@@ -126,6 +126,64 @@
         "precision": {
           "type": "number",
           "description": "Property. Precision measures the standard deviation of a dataset. That is, it measures how close the values in the dataset are to each other"
+        },
+        "dataQualityAssessmentVariableNames": {
+          "type": "array",
+          "description": "Array of variable names used to describe the values for each dataQualityAssessmentDomain property",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dataQualityAssessmentDomains": {
+          "type": "object",
+          "description": "Data quality assessment domains with their respective scores",
+          "properties": {
+            "completeness": {
+              "type": "array",
+              "description": "Completeness scores for variables",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "consistency": {
+              "type": "array",
+              "description": "Consistency scores for variables",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "timeliness": {
+              "type": "array",
+              "description": "Timeliness scores for variables",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "uniqueness": {
+              "type": "array",
+              "description": "Uniqueness scores for variables",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "validity": {
+              "type": "array",
+              "description": "Validity scores for variables",
+              "items": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Extended the schema to incude 2 new properties for a use case in WATERVERSE. I didn't include the new properties in the examples since they are not required for the model.